### PR TITLE
ブラウザに入った時、始めにトップページを開く設定に変更

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -21,8 +21,8 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    // public const HOME = '/home'; //元の記述
-    public const Home = '/articles'; //記事一覧画面に変更
+    public const HOME = '/home'; //元の記述
+    // public const Home = '/articles'; //記事一覧画面に変更
 
     /**
      * Define your route model bindings, pattern filters, etc.


### PR DESCRIPTION
ユーザー登録ページに移動する時に500エラーが出るために一旦トップページを開く設定に戻す

public const Home = '/articles';
↓
public const HOME = '/home';