### PR TITLE
タグ入力フォームの確定キー種類をカスタマイズ

### DIFF
--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -11,6 +11,7 @@
       :tags="tags"
       placeholder="タグを5個まで入力できます"
       :autocomplete-items="filteredItems"
+      :add-on-key="[13, 32]"
       @tags-changed="newTags => tags = newTags"
     />
   </div>


### PR DESCRIPTION
タグ入力フォームの確定キー種類をカスタマイズ

スペースキーでも確定できるようにする。